### PR TITLE
Chore/use cobalt aws mulipart upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "cobalt-aws"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fab1ea671d0d81a8d8be2cf943aa3be2a8318a074ef5c7d8ae1695e117afb3b"
+checksum = "d41be17e5ba8227837a9459556a7d028fcc498a74e0a66cba2f009052c9bcdd7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ aws-config = "0.51.0"
 aws-sdk-s3 = "0.21.0"
 bytesize = "1.1.0"
 clap = { version = "4.0.27", features = ["derive"] }
-cobalt-aws = "0.9.0"
+cobalt-aws = "0.9.1"
 futures = "0.3.25"
 pin-project-lite = "0.2.9"
 serde = { version = "1.0.148", features = ["derive"] }

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -19,7 +19,7 @@ use tokio::io::{AsyncRead, AsyncSeek};
 use aws_sdk_s3::Client;
 use tracing::{event, instrument, Level};
 
-use crate::S3Object;
+use cobalt_aws::s3::S3Object;
 
 /// Convenience wrapper for boxed future
 type MultipartUploadFuture<'a> =

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,18 +1,14 @@
 //! Provides ways of interacting with objects in S3.
 
 use anyhow::Context as anyContext;
-use aws_sdk_s3::error::{CompleteMultipartUploadError, GetObjectError, UploadPartError};
-use aws_sdk_s3::model::CompletedMultipartUpload;
-use aws_sdk_s3::model::CompletedPart;
-use aws_sdk_s3::model::ObjectCannedAcl;
-use aws_sdk_s3::output::{CompleteMultipartUploadOutput, GetObjectOutput, UploadPartOutput};
-use aws_sdk_s3::types::{ByteStream, SdkError};
-use bytesize::{GIB, MIB};
+use aws_sdk_s3::error::GetObjectError;
+use aws_sdk_s3::output::GetObjectOutput;
+use aws_sdk_s3::types::SdkError;
+use bytesize::MIB;
 use futures::future::BoxFuture;
 use futures::io::{Error, ErrorKind};
 use futures::task::{Context, Poll};
-use futures::{ready, AsyncWrite, Future, FutureExt, TryFutureExt};
-use std::mem;
+use futures::{Future, TryFutureExt};
 use std::pin::Pin;
 use tokio::io::{AsyncRead, AsyncSeek};
 
@@ -20,389 +16,6 @@ use aws_sdk_s3::Client;
 use tracing::{event, instrument, Level};
 
 use cobalt_aws::s3::S3Object;
-
-/// Convenience wrapper for boxed future
-type MultipartUploadFuture<'a> =
-    BoxFuture<'a, Result<(UploadPartOutput, i32), SdkError<UploadPartError>>>;
-/// Convenience wrapper for boxed future
-type CompleteMultipartUploadFuture<'a> =
-    BoxFuture<'a, Result<CompleteMultipartUploadOutput, SdkError<CompleteMultipartUploadError>>>;
-
-/// Holds state for the [AsyncMultipartUpload]
-enum AsyncMultipartUploadState<'a> {
-    ///Bytes are being written
-    Writing {
-        /// Multipart Uploads that are running
-        uploads: Vec<MultipartUploadFuture<'a>>,
-        /// Bytes waiting to be written.
-        buffer: Vec<u8>,
-        /// The next part number to be used.
-        part_number: i32,
-        /// The completed parts
-        completed_parts: Vec<CompletedPart>,
-    },
-    /// close() has been called and parts are still uploading.
-    CompletingParts {
-        uploads: Vec<MultipartUploadFuture<'a>>,
-        completed_parts: Vec<CompletedPart>,
-    },
-    /// All parts have been uploaded and the CompleteMultipart is returning.
-    Completing(CompleteMultipartUploadFuture<'a>),
-    // We have completed writing to S3.
-    Closed,
-}
-
-/// Configuration for the AsyncMultipartUpload which
-/// is separate from the state.
-/// This was to work around borrowing of two disjoint fields
-/// allowing this structure to be cloned.
-#[derive(Clone, Debug)]
-struct AsyncMultipartUploadConfig<'a> {
-    client: &'a Client,
-    bucket: String,
-    key: String,
-    upload_id: String,
-    part_size: usize,
-    max_uploading_parts: usize,
-}
-
-/// A implementation of [AsyncWrite] for S3 objects using multipart uploads.
-/// By using multipart uploads constant memory usage can be achieved.
-///
-/// ## Note
-/// On failure the multipart upload is not aborted. It is up to the
-/// caller to call the S3 `abortMultipartUpload` API when required.
-pub struct AsyncMultipartUpload<'a> {
-    config: AsyncMultipartUploadConfig<'a>,
-    state: AsyncMultipartUploadState<'a>,
-}
-
-/// Minimum size of a multipart upload.
-const MIN_PART_SIZE: usize = 5_usize * MIB as usize; // 5 Mib
-/// Maximum size of a multipart upload.
-const MAX_PART_SIZE: usize = 5_usize * GIB as usize; // 5 Gib
-
-/// Default number of part which can be uploaded
-/// concurrently.
-const DEFAULT_MAX_UPLOADING_PARTS: usize = 100;
-
-impl<'a> AsyncMultipartUpload<'a> {
-    /// Create a new [AsyncMultipartUpload].
-    ///
-    /// * `client`              - S3 client to use.
-    /// * `bucket`              - Bucket to write the object into.
-    /// * `key`                 - Key to write the object into.
-    /// * `part_size`           - How large, in bytes, each part should be.
-    /// * `max_uploading_parts` - How many parts to upload concurrently.
-    #[instrument(skip(client))]
-    pub async fn new(
-        client: &'a Client,
-        bucket: &'a str,
-        key: &'a str,
-        part_size: usize,
-        max_uploading_parts: Option<usize>,
-    ) -> anyhow::Result<AsyncMultipartUpload<'a>> {
-        event!(Level::DEBUG, "New AsyncMultipartUpload");
-        if part_size < MIN_PART_SIZE {
-            anyhow::bail!("part_size was {part_size}, can not be less than {MIN_PART_SIZE}")
-        }
-        if part_size > MAX_PART_SIZE {
-            anyhow::bail!("part_size was {part_size}, can not be more than {MAX_PART_SIZE}")
-        }
-
-        if max_uploading_parts.unwrap_or(DEFAULT_MAX_UPLOADING_PARTS) == 0 {
-            anyhow::bail!("Max uploading parts must not be 0")
-        }
-
-        let result = client
-            .create_multipart_upload()
-            .bucket(bucket)
-            .key(key)
-            .acl(ObjectCannedAcl::BucketOwnerFullControl)
-            .send()
-            .await?;
-
-        use anyhow::Context;
-        let upload_id = result.upload_id().context("Expected Upload Id")?;
-
-        Ok(AsyncMultipartUpload {
-            config: AsyncMultipartUploadConfig {
-                client,
-                bucket: bucket.into(),
-                key: key.into(),
-                upload_id: upload_id.into(),
-                part_size,
-                max_uploading_parts: max_uploading_parts.unwrap_or(DEFAULT_MAX_UPLOADING_PARTS),
-            },
-            state: AsyncMultipartUploadState::Writing {
-                uploads: vec![],
-                buffer: Vec::with_capacity(part_size),
-                part_number: 1,
-                completed_parts: vec![],
-            },
-        })
-    }
-
-    #[instrument(skip(buffer))]
-    fn upload_part<'b>(
-        config: &AsyncMultipartUploadConfig,
-        buffer: Vec<u8>,
-        part_number: i32,
-    ) -> MultipartUploadFuture<'b> {
-        event!(Level::DEBUG, "Uploading Part");
-        config
-            .client
-            .upload_part()
-            .bucket(&config.bucket)
-            .key(&config.key)
-            .upload_id(&config.upload_id)
-            .part_number(part_number)
-            .body(ByteStream::from(buffer))
-            .send()
-            .map_ok(move |p| (p, part_number))
-            .boxed()
-    }
-
-    fn poll_all<T>(futures: &mut Vec<BoxFuture<T>>, cx: &mut Context) -> Vec<T> {
-        let mut pending = vec![];
-        let mut complete = vec![];
-
-        while let Some(mut f) = futures.pop() {
-            match Pin::new(&mut f).poll(cx) {
-                Poll::Ready(result) => complete.push(result),
-                Poll::Pending => pending.push(f),
-            }
-        }
-        futures.extend(pending);
-        complete
-    }
-
-    #[instrument]
-    fn try_collect_complete_parts(
-        complete_results: Vec<Result<(UploadPartOutput, i32), SdkError<UploadPartError>>>,
-    ) -> Result<Vec<CompletedPart>, Error> {
-        complete_results
-            .into_iter()
-            .map(|r| r.map_err(|e| Error::new(ErrorKind::Other, e)))
-            .map(|r| {
-                r.map(|(c, part_number)| {
-                    CompletedPart::builder()
-                        .set_e_tag(c.e_tag)
-                        .part_number(part_number)
-                        .build()
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()
-    }
-
-    #[instrument]
-    fn complete_multipart_upload<'b>(
-        config: &AsyncMultipartUploadConfig,
-        completed_parts: Vec<CompletedPart>,
-    ) -> CompleteMultipartUploadFuture<'b> {
-        config
-            .client
-            .complete_multipart_upload()
-            .key(&config.key)
-            .bucket(&config.bucket)
-            .upload_id(&config.upload_id)
-            .multipart_upload(
-                CompletedMultipartUpload::builder()
-                    .set_parts(Some(completed_parts))
-                    .build(),
-            )
-            .send()
-            .boxed()
-    }
-
-    #[instrument(skip(uploads))]
-    fn check_uploads(
-        uploads: &mut Vec<MultipartUploadFuture<'a>>,
-        completed_parts: &mut Vec<CompletedPart>,
-        cx: &mut Context,
-    ) -> Result<(), Error> {
-        let complete_results = AsyncMultipartUpload::poll_all(uploads, cx);
-        let new_completed_parts =
-            AsyncMultipartUpload::try_collect_complete_parts(complete_results)?;
-        completed_parts.extend(new_completed_parts);
-        Ok(())
-    }
-}
-
-impl<'a> AsyncWrite for AsyncMultipartUpload<'a> {
-    #[instrument(skip(self, cx, buf))]
-    fn poll_write(
-        mut self: Pin<&mut AsyncMultipartUpload<'a>>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, Error>> {
-        // I'm not sure how to work around borrow of two disjoint fields.
-        // I had lifetime issues trying to implement Split Borrows
-        event!(Level::DEBUG, "Polling write");
-        let config = self.config.clone();
-        match &mut self.state {
-            AsyncMultipartUploadState::Writing {
-                uploads,
-                buffer,
-                part_number,
-                completed_parts,
-            } => {
-                event!(Level::DEBUG, "Polling write while Writing");
-                //Poll current uploads to make space for in coming data
-                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
-                //only take enough bytes to fill remaining upload capacity
-                let upload_capacity = ((config.max_uploading_parts - uploads.len())
-                    * config.part_size)
-                    - buffer.len();
-                let bytes_to_write = std::cmp::min(upload_capacity, buf.len());
-                // No capacity to upload
-                if bytes_to_write == 0 {
-                    uploads.is_empty().then(|| cx.waker().wake_by_ref());
-                    return Poll::Pending;
-                }
-                buffer.extend(&buf[..bytes_to_write]);
-
-                //keep pushing uploads until the buffer is small than the part size
-                while buffer.len() >= config.part_size {
-                    event!(Level::DEBUG, "Starting a new part upload");
-                    let mut part = buffer.split_off(config.part_size);
-                    // We want to consume the first part of the buffer and upload it to S3.
-                    // The split_off call does this but it's the wrong way around.
-                    // Use `mem:swap` to reverse the two variables in place.
-                    std::mem::swap(buffer, &mut part);
-                    //Upload a new part
-                    let part_upload =
-                        AsyncMultipartUpload::upload_part(&config, part, *part_number);
-                    uploads.push(part_upload);
-                    *part_number += 1;
-                }
-                //Poll all uploads, remove complete and fetch their results.
-                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
-                //Return number of bytes written from the input
-                Poll::Ready(Ok(bytes_to_write))
-            }
-            _ => Poll::Ready(Err(Error::new(
-                ErrorKind::Other,
-                "Attempted to .write() after .close().",
-            ))),
-        }
-    }
-
-    #[instrument(skip(self, cx))]
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
-        //Ensure all pending uploads are completed.
-        match &mut self.state {
-            AsyncMultipartUploadState::Writing {
-                uploads,
-                completed_parts,
-                ..
-            } => {
-                event!(Level::DEBUG, "Flushing Multipart Uploads");
-                //Poll uploads and mark as completed
-                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
-                if uploads.is_empty() {
-                    event!(Level::DEBUG, "All part uploads are complete");
-                    Poll::Ready(Ok(()))
-                } else {
-                    event!(Level::DEBUG, "Waiting for uploads to complete");
-                    //Assume that polled futures will trigger a wake
-                    Poll::Pending
-                }
-            }
-            _ => Poll::Ready(Err(Error::new(
-                ErrorKind::Other,
-                "Attempted to .flush() writer after .close().",
-            ))),
-        }
-    }
-
-    #[instrument(skip(self, cx))]
-    fn poll_close<'b>(
-        mut self: Pin<&'b mut AsyncMultipartUpload<'a>>,
-        cx: &'b mut Context<'_>,
-    ) -> Poll<Result<(), Error>> {
-        event!(Level::DEBUG, "Closing Multipart Uploads");
-        let config = self.config.clone();
-        match &mut self.state {
-            AsyncMultipartUploadState::Writing {
-                buffer,
-                uploads,
-                completed_parts,
-                part_number,
-            } => {
-                event!(Level::DEBUG, "Creating final Part Upload");
-                //make space for final upload
-                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
-                if config.max_uploading_parts - uploads.len() == 0 {
-                    event!(Level::DEBUG, "Waiting for available upload capacity");
-                    return Poll::Pending;
-                }
-                if !buffer.is_empty() {
-                    let buff = mem::take(buffer);
-                    let part = AsyncMultipartUpload::upload_part(&config, buff, *part_number);
-                    uploads.push(part);
-                }
-                //Poll all uploads, remove complete and fetch their results.
-                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
-                // If no remaining uploads then trigger a wake to move to next state
-                uploads.is_empty().then(|| cx.waker().wake_by_ref());
-                // Change state to Completing parts
-                self.state = AsyncMultipartUploadState::CompletingParts {
-                    uploads: mem::take(uploads),
-                    completed_parts: mem::take(completed_parts),
-                };
-                Poll::Pending
-            }
-            AsyncMultipartUploadState::CompletingParts {
-                uploads,
-                completed_parts,
-            } if uploads.is_empty() => {
-                event!(
-                    Level::DEBUG,
-                    "AsyncS3Upload all parts uploaded, Completing Upload"
-                );
-                //Once uploads are empty change state to Completing
-                let mut completed_parts = mem::take(completed_parts);
-                // This was surprising but was needed to complete the upload.
-                completed_parts.sort_by_key(|p| p.part_number());
-                let completing =
-                    AsyncMultipartUpload::complete_multipart_upload(&config, completed_parts);
-                self.state = AsyncMultipartUploadState::Completing(completing);
-                // Trigger a wake to run with new state and poll the future
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            AsyncMultipartUploadState::CompletingParts {
-                uploads,
-                completed_parts,
-            } => {
-                event!(
-                    Level::DEBUG,
-                    "AsyncS3Upload Waiting for All Parts to Upload"
-                );
-                //Poll all uploads, remove complete and fetch their results.
-                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
-                //Trigger a wake if all uploads have completed
-                uploads.is_empty().then(|| cx.waker().wake_by_ref());
-                Poll::Pending
-            }
-            AsyncMultipartUploadState::Completing(fut) => {
-                //use ready! macro to wait for complete uploaded to be done
-                //ready! is like the ? but for Poll objects returning `Polling` if not Ready
-                event!(Level::DEBUG, "Waiting for upload complete to finish");
-                let result = ready!(Pin::new(fut).poll(cx))
-                    .map(|_| ())
-                    .map_err(|e| Error::new(ErrorKind::Other, e)); //set state to closed
-                self.state = AsyncMultipartUploadState::Closed;
-                Poll::Ready(result)
-            }
-            AsyncMultipartUploadState::Closed => Poll::Ready(Err(Error::new(
-                ErrorKind::Other,
-                "Attempted to .close() writer after .close().",
-            ))),
-        }
-    }
-}
 
 type GetObjectFuture<'a> = BoxFuture<'a, Result<GetObjectOutput, SdkError<GetObjectError>>>;
 
@@ -647,25 +260,28 @@ impl<'a> AsyncSeek for S3ObjectSeekableRead<'a> {
 
 #[cfg(test)]
 mod tests {
+    use bytesize::GIB;
+    use cobalt_aws::s3::AsyncMultipartUpload;
+
     use super::*;
 
     #[tokio::test]
     async fn test_part_size_too_small() {
         let shared_config = aws_config::load_from_env().await;
         let client = aws_sdk_s3::Client::new(&shared_config);
-        assert!(
-            AsyncMultipartUpload::new(&client, "bucket", "key", 0_usize, None)
-                .await
-                .is_err()
-        )
+        let dst = S3Object::new("bucket", "key");
+        assert!(AsyncMultipartUpload::new(&client, &dst, 0_usize, None)
+            .await
+            .is_err())
     }
 
     #[tokio::test]
     async fn test_part_size_too_big() {
         let shared_config = aws_config::load_from_env().await;
         let client = aws_sdk_s3::Client::new(&shared_config);
+        let dst = S3Object::new("bucket", "key");
         assert!(
-            AsyncMultipartUpload::new(&client, "bucket", "key", 5 * GIB as usize + 1, None)
+            AsyncMultipartUpload::new(&client, &dst, 5 * GIB as usize + 1, None)
                 .await
                 .is_err()
         )
@@ -675,8 +291,9 @@ mod tests {
     async fn test_max_uploading_parts_is_zero() {
         let shared_config = aws_config::load_from_env().await;
         let client = aws_sdk_s3::Client::new(&shared_config);
+        let dst = S3Object::new("bucket", "key");
         assert!(
-            AsyncMultipartUpload::new(&client, "bucket", "key", 5 * MIB as usize, Some(0))
+            AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, Some(0))
                 .await
                 .is_err()
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@ use crate::counter::ByteLimit;
 use anyhow::Error;
 use anyhow::{ensure, Context, Result};
 use async_zip::{Compression as AsyncCompression, ZipEntryBuilder};
-use aws::AsyncMultipartUpload;
 use aws_sdk_s3::output::GetObjectOutput;
 use checksum::CRC32Sink;
 use clap::ValueEnum;
+use cobalt_aws::s3::AsyncMultipartUpload;
 use cobalt_aws::s3::S3Object;
 use futures::future;
 use futures::lock::Mutex;
@@ -186,14 +186,8 @@ impl<'a> Archiver<'a> {
         );
 
         //Create the upload and the zip writer.
-        let upload = AsyncMultipartUpload::new(
-            client,
-            &output_location.bucket,
-            &output_location.key,
-            self.part_size,
-            None,
-        )
-        .await?;
+        let upload =
+            AsyncMultipartUpload::new(client, output_location, self.part_size, None).await?;
 
         let mut byte_limit =
             ByteLimit::new_from_inner(upload, MAX_ZIP_FILE_SIZE_BYTES.into()).compat_write();

--- a/src/main_cli.rs
+++ b/src/main_cli.rs
@@ -3,8 +3,9 @@ use aws_sdk_s3::Client;
 use bytesize::ByteSize;
 use clap::{Parser, Subcommand, ValueEnum};
 use cobalt_aws::config;
+use cobalt_aws::s3::S3Object;
 use futures::prelude::*;
-use s3_archiver::{Compression, S3Object};
+use s3_archiver::Compression;
 use std::io::{BufRead, BufReader};
 use tracing_subscriber::EnvFilter;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -129,12 +129,13 @@ pub mod fixtures {
     use aws_sdk_s3::types::SdkError;
     use aws_sdk_s3::Client;
     use bytesize::MIB;
+    use cobalt_aws::s3::S3Object;
     use rand::distributions::{Alphanumeric, DistString};
     use rand::Rng;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
+    use s3_archiver::Compression;
     use s3_archiver::ManifestEntry;
-    use s3_archiver::{Compression, S3Object};
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
     use typed_builder::TypedBuilder;

--- a/tests/test_aws.rs
+++ b/tests/test_aws.rs
@@ -4,12 +4,13 @@ use std::io::SeekFrom;
 
 use ::function_name::named;
 use bytesize::MIB;
+use cobalt_aws::s3::S3Object;
 use common::aws::S3TestClient;
 use common::fixtures;
 use futures::prelude::*;
 use s3_archiver::aws::{AsyncMultipartUpload, S3ObjectSeekableRead};
-use s3_archiver::S3Object;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
 #[cfg(feature = "test_containers")]
 use {futures::lock::Mutex, futures::stream, std::sync::Arc};
 

--- a/tests/test_aws.rs
+++ b/tests/test_aws.rs
@@ -126,8 +126,9 @@ async fn test_fail_failed_write() {
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
 
     let part_len = 5 * MIB as usize;
+    let dst = S3Object::new(test_bucket, &dst_key);
     let upload = Arc::new(Mutex::new(
-        AsyncMultipartUpload::new(&client, test_bucket, &dst_key, part_len, None)
+        AsyncMultipartUpload::new(&client, &dst ,part_len, None)
             .await
             .unwrap(),
     ));
@@ -166,9 +167,10 @@ async fn test_fail_write() {
 
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
 
+    let dst = S3Object::new(test_bucket, &dst_key);
+
     let mut upload =
-        AsyncMultipartUpload::new(&client, test_bucket, &dst_key, 5 * MIB as usize, None)
-            .await
+        AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None) .await
             .unwrap();
 
     let data_len = 6 * MIB as usize;
@@ -190,8 +192,9 @@ async fn test_fail_close() {
 
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
 
+    let dst = S3Object::new(test_bucket, &dst_key);
     let mut upload =
-        AsyncMultipartUpload::new(&client, test_bucket, &dst_key, 5 * MIB as usize, None)
+        AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None)
             .await
             .unwrap();
 

--- a/tests/test_aws.rs
+++ b/tests/test_aws.rs
@@ -4,11 +4,12 @@ use std::io::SeekFrom;
 
 use ::function_name::named;
 use bytesize::MIB;
+use cobalt_aws::s3::AsyncMultipartUpload;
 use cobalt_aws::s3::S3Object;
 use common::aws::S3TestClient;
 use common::fixtures;
 use futures::prelude::*;
-use s3_archiver::aws::{AsyncMultipartUpload, S3ObjectSeekableRead};
+use s3_archiver::aws::S3ObjectSeekableRead;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 #[cfg(feature = "test_containers")]
@@ -26,10 +27,11 @@ async fn test_put_single_part() {
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
     let buffer_len = MIB as usize;
 
-    let mut upload =
-        AsyncMultipartUpload::new(&client, test_bucket, &dst_key, 5_usize * MIB as usize, None)
-            .await
-            .unwrap();
+    let dst = S3Object::new(test_bucket, &dst_key);
+
+    let mut upload = AsyncMultipartUpload::new(&client, &dst, 5_usize * MIB as usize, None)
+        .await
+        .unwrap();
     upload.write_all(&vec![0; buffer_len]).await.unwrap();
     upload.close().await.unwrap();
     let body = fixtures::fetch_bytes(&client, &S3Object::new(test_bucket, &dst_key))
@@ -50,10 +52,10 @@ async fn test_put_10mb() {
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
     let data_len = 10 * MIB as usize;
 
-    let mut upload =
-        AsyncMultipartUpload::new(&client, test_bucket, &dst_key, 5 * MIB as usize, None)
-            .await
-            .unwrap();
+    let dst = S3Object::new(test_bucket, &dst_key);
+    let mut upload = AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None)
+        .await
+        .unwrap();
     upload.write_all(&vec![0; data_len]).await.unwrap();
     upload.close().await.unwrap();
     let body = fixtures::fetch_bytes(&client, &S3Object::new(test_bucket, &dst_key))
@@ -73,10 +75,10 @@ async fn test_put_14mb() {
 
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
 
-    let mut upload =
-        AsyncMultipartUpload::new(&client, test_bucket, &dst_key, 5 * MIB as usize, None)
-            .await
-            .unwrap();
+    let dst = S3Object::new(test_bucket, dst_key);
+    let mut upload = AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None)
+        .await
+        .unwrap();
 
     let data_len = 14 * MIB as usize;
 
@@ -95,10 +97,10 @@ async fn test_put_16mb_single_upload() {
 
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
 
-    let mut upload =
-        AsyncMultipartUpload::new(&client, test_bucket, &dst_key, 5 * MIB as usize, Some(1))
-            .await
-            .unwrap();
+    let dst = S3Object::new(test_bucket, &dst_key);
+    let mut upload = AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, Some(1))
+        .await
+        .unwrap();
 
     let data_len = 16 * MIB as usize;
 
@@ -211,10 +213,10 @@ async fn test_s3objectseekableread() {
 
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
 
-    let mut upload =
-        AsyncMultipartUpload::new(&client, test_bucket, &dst_key, 5 * MIB as usize, None)
-            .await
-            .unwrap();
+    let dst = S3Object::new(test_bucket, &dst_key);
+    let mut upload = AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None)
+        .await
+        .unwrap();
 
     let data_len = 6 * MIB as usize;
     upload.write_all(&vec![0; data_len]).await.unwrap();
@@ -242,10 +244,10 @@ async fn test_s3objectseekableread_seek() {
 
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
 
-    let mut upload =
-        AsyncMultipartUpload::new(&client, test_bucket, &dst_key, 5 * MIB as usize, None)
-            .await
-            .unwrap();
+    let dst = S3Object::new(test_bucket, &dst_key);
+    let mut upload = AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None)
+        .await
+        .unwrap();
 
     let data_len = 6 * MIB as usize;
     upload.write_all(&vec![0; data_len]).await.unwrap();
@@ -275,10 +277,10 @@ async fn test_s3objectseekableread_seek_jump() {
 
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
 
-    let mut upload =
-        AsyncMultipartUpload::new(&client, test_bucket, &dst_key, 5 * MIB as usize, None)
-            .await
-            .unwrap();
+    let dst = S3Object::new(test_bucket, &dst_key);
+    let mut upload = AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None)
+        .await
+        .unwrap();
 
     let data_len = 6 * MIB as usize;
     upload.write_all(&vec![0; data_len]).await.unwrap();

--- a/tests/test_aws.rs
+++ b/tests/test_aws.rs
@@ -128,7 +128,7 @@ async fn test_fail_failed_write() {
     let part_len = 5 * MIB as usize;
     let dst = S3Object::new(test_bucket, &dst_key);
     let upload = Arc::new(Mutex::new(
-        AsyncMultipartUpload::new(&client, &dst ,part_len, None)
+        AsyncMultipartUpload::new(&client, &dst, part_len, None)
             .await
             .unwrap(),
     ));
@@ -169,9 +169,9 @@ async fn test_fail_write() {
 
     let dst = S3Object::new(test_bucket, &dst_key);
 
-    let mut upload =
-        AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None) .await
-            .unwrap();
+    let mut upload = AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None)
+        .await
+        .unwrap();
 
     let data_len = 6 * MIB as usize;
 
@@ -193,10 +193,9 @@ async fn test_fail_close() {
     fixtures::create_bucket(&client, test_bucket).await.unwrap();
 
     let dst = S3Object::new(test_bucket, &dst_key);
-    let mut upload =
-        AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None)
-            .await
-            .unwrap();
+    let mut upload = AsyncMultipartUpload::new(&client, &dst, 5 * MIB as usize, None)
+        .await
+        .unwrap();
 
     let data_len = 6 * MIB as usize;
 

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -3,6 +3,7 @@ pub mod common;
 use ::function_name::named;
 use assert_cmd::Command;
 use bytesize::MIB;
+use cobalt_aws::s3::S3Object;
 use common::aws::S3TestClient;
 use common::fixtures;
 use std::collections::HashMap;
@@ -55,7 +56,7 @@ async fn test_cli_run() {
         .unwrap();
 
     let dst_key = fixtures::gen_random_file_name(&mut rng);
-    let dst_obj = s3_archiver::S3Object::new("dst-bucket", &dst_key);
+    let dst_obj = S3Object::new("dst-bucket", &dst_key);
     fixtures::create_bucket(&client, &dst_obj.bucket)
         .await
         .unwrap();
@@ -98,7 +99,7 @@ async fn test_cli_run_with_size() {
         .unwrap();
 
     let dst_key = fixtures::gen_random_file_name(&mut rng);
-    let dst_obj = s3_archiver::S3Object::new("dst-bucket", &dst_key);
+    let dst_obj = S3Object::new("dst-bucket", &dst_key);
     fixtures::create_bucket(&client, &dst_obj.bucket)
         .await
         .unwrap();
@@ -143,7 +144,7 @@ async fn test_cli_run_with_src_fetch_buffer() {
         .unwrap();
 
     let dst_key = fixtures::gen_random_file_name(&mut rng);
-    let dst_obj = s3_archiver::S3Object::new("dst-bucket", &dst_key);
+    let dst_obj = S3Object::new("dst-bucket", &dst_key);
     fixtures::create_bucket(&client, &dst_obj.bucket)
         .await
         .unwrap();
@@ -188,12 +189,12 @@ async fn test_cli_run_with_src_manifest() {
         .unwrap();
 
     let dst_key = fixtures::gen_random_file_name(&mut rng);
-    let dst_obj = s3_archiver::S3Object::new("dst-bucket", &dst_key);
+    let dst_obj = S3Object::new("dst-bucket", &dst_key);
     fixtures::create_bucket(&client, &dst_obj.bucket)
         .await
         .unwrap();
     let manifest_key = fixtures::gen_random_file_name(&mut rng);
-    let manifest_obj = s3_archiver::S3Object::new("dst-bucket", &manifest_key);
+    let manifest_obj = S3Object::new("dst-bucket", &manifest_key);
     let mut cmd = Command::cargo_bin("s3-archiver-cli").unwrap();
     cmd.arg("archive");
     cmd.arg(Url::try_from(&dst_obj).unwrap().as_str());
@@ -249,7 +250,7 @@ async fn test_cli_no_trailing_slash_prefix() {
     let mut rng = fixtures::seeded_rng(function_name!());
 
     let dst_key = fixtures::gen_random_file_name(&mut rng);
-    let dst_obj = s3_archiver::S3Object::new("dst-bucket", &dst_key);
+    let dst_obj = S3Object::new("dst-bucket", &dst_key);
     fixtures::create_bucket(&client, &dst_obj.bucket)
         .await
         .unwrap();
@@ -270,7 +271,7 @@ async fn test_cli_has_leading_slash_prefix() {
     let mut rng = fixtures::seeded_rng(function_name!());
 
     let dst_key = fixtures::gen_random_file_name(&mut rng);
-    let dst_obj = s3_archiver::S3Object::new("dst-bucket", &dst_key);
+    let dst_obj = S3Object::new("dst-bucket", &dst_key);
     fixtures::create_bucket(&client, &dst_obj.bucket)
         .await
         .unwrap();
@@ -291,7 +292,7 @@ async fn test_invalid_s3_src() {
     let mut rng = fixtures::seeded_rng(function_name!());
 
     let dst_key = fixtures::gen_random_file_name(&mut rng);
-    let dst_obj = s3_archiver::S3Object::new("dst-bucket", &dst_key);
+    let dst_obj = S3Object::new("dst-bucket", &dst_key);
     fixtures::create_bucket(&client, &dst_obj.bucket)
         .await
         .unwrap();
@@ -313,7 +314,7 @@ async fn test_invalid_part_size_0b() {
     let mut rng = fixtures::seeded_rng(function_name!());
 
     let dst_key = fixtures::gen_random_file_name(&mut rng);
-    let dst_obj = s3_archiver::S3Object::new("dst-bucket", &dst_key);
+    let dst_obj = S3Object::new("dst-bucket", &dst_key);
     fixtures::create_bucket(&client, &dst_obj.bucket)
         .await
         .unwrap();
@@ -335,7 +336,7 @@ async fn test_invalid_part_size_1k() {
     let mut rng = fixtures::seeded_rng(function_name!());
 
     let dst_key = fixtures::gen_random_file_name(&mut rng);
-    let dst_obj = s3_archiver::S3Object::new("dst-bucket", &dst_key);
+    let dst_obj = S3Object::new("dst-bucket", &dst_key);
     fixtures::create_bucket(&client, &dst_obj.bucket)
         .await
         .unwrap();
@@ -357,9 +358,9 @@ async fn test_manifest_file_and_generate() {
     let mut rng = fixtures::seeded_rng(function_name!());
 
     let dst_key = fixtures::gen_random_file_name(&mut rng);
-    let dst_obj = s3_archiver::S3Object::new("dst-bucket", &dst_key);
+    let dst_obj = S3Object::new("dst-bucket", &dst_key);
     let manifest_key = fixtures::gen_random_file_name(&mut rng);
-    let manifest_obj = s3_archiver::S3Object::new("dst-bucket", &manifest_key);
+    let manifest_obj = S3Object::new("dst-bucket", &manifest_key);
     fixtures::create_bucket(&client, &dst_obj.bucket)
         .await
         .unwrap();

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -1,11 +1,12 @@
 pub mod common;
 
 use ::function_name::named;
+use cobalt_aws::s3::S3Object;
 use common::aws::S3TestClient;
 use common::fixtures;
 use futures::prelude::*;
 use rand::Rng;
-use s3_archiver::{Compression, ManifestEntry, S3Object};
+use s3_archiver::{Compression, ManifestEntry};
 use std::io::prelude::*;
 
 #[tokio::test]


### PR DESCRIPTION
## What

Remove S3Object and AsyncMultipartUpload and use version in `cobalt-aws`.
Bump `cobalt-aws` version.

## Why

The `AsyncMultipartUpload` has been moved into `cobalt-aws`

