### PR TITLE
feat/unarchive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Unarchive command to extract files into S3.
+
 ## 0.1.0
 
 - Initial release of the `cobalt-s3-archiver` crate.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Commands:
   archive            Create an ZIP archive in S3 from source files in S3
   validate-archive   Validate a ZIP archive matches the given manifest
   validate-manifest  Validate the calculated crc32 of files in the manifest match those recorded the manifest
+  unarchive          Extract compressed files from archive
   help               Print this message or the help of the given subcommand(s)
 
 Options:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,9 @@ pub async fn validate_zip_entry_bytes(
     Ok(())
 }
 
+/// Extract all files from the ZIP at the `zip_file` location into the destination prefix.
+/// If any of the files in the ZIP are larger than `chunk_size` then is is uploaded to S3
+/// as a multipart upload.
 pub async fn unarchive_all(
     client: &aws_sdk_s3::Client,
     zip_file: &S3Object,

--- a/src/main_cli.rs
+++ b/src/main_cli.rs
@@ -25,7 +25,7 @@ enum Command {
     ///Validate the calculated crc32 of files in the manifest match those recorded the manifest.
     ValidateManifest(ValidateManifestCommand),
     ///Extract compressed files from archive.
-    Unarchive(UnArchiveCommand),
+    Unarchive(UnarchiveCommand),
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
@@ -68,7 +68,7 @@ struct ArchiveCommand {
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
-struct UnArchiveCommand {
+struct UnarchiveCommand {
     /// S3 input ZIP object `s3://{bucket}/{key}`
     input_location: S3Object,
     /// S3 output location `s3://{bucket}/{key}`

--- a/src/main_cli.rs
+++ b/src/main_cli.rs
@@ -69,10 +69,15 @@ struct ArchiveCommand {
 
 #[derive(Parser, Debug, PartialEq, Clone)]
 struct UnArchiveCommand {
-    /// S3 input object `s3://{bucket}/{key}`
+    /// S3 input ZIP object `s3://{bucket}/{key}`
     input_location: S3Object,
     /// S3 output location `s3://{bucket}/{key}`
     output_location: S3Object,
+    /// Part size to use in multipart upload.
+    /// Accepts human readable bytes e.g. K, KiB.
+    /// Min 5MiB, Max 5GiB.
+    #[clap(short = 's', long = "part-size", default_value = "5MiB")]
+    part_size: ByteSize,
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
@@ -203,8 +208,13 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Command::Unarchive(cmd) => {
-            cobalt_s3_archiver::unarchive_all(&client, &cmd.input_location, &cmd.output_location)
-                .await
+            cobalt_s3_archiver::unarchive_all(
+                &client,
+                &cmd.input_location,
+                &cmd.output_location,
+                usize::try_from(cmd.part_size.as_u64())?,
+            )
+            .await
         }
     }
 }

--- a/src/main_cli.rs
+++ b/src/main_cli.rs
@@ -24,6 +24,8 @@ enum Command {
     ValidateArchive(ValidateCommand),
     ///Validate the calculated crc32 of files in the manifest match those recorded the manifest.
     ValidateManifest(ValidateManifestCommand),
+    ///Extract compressed files from archive.
+    Unarchive(UnArchiveCommand),
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
@@ -63,6 +65,14 @@ struct ArchiveCommand {
     /// Some tools can not read ZIP files using data descriptors.
     #[clap(short = 'd', long = "data-descriptors")]
     data_descriptors: bool,
+}
+
+#[derive(Parser, Debug, PartialEq, Clone)]
+struct UnArchiveCommand {
+    /// S3 input object `s3://{bucket}/{key}`
+    input_location: S3Object,
+    /// S3 output location `s3://{bucket}/{key}`
+    output_location: S3Object,
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
@@ -191,6 +201,10 @@ async fn main() -> Result<()> {
                     &manifest_object
                 );
             Ok(())
+        }
+        Command::Unarchive(cmd) => {
+            cobalt_s3_archiver::unarchive_all(&client, &cmd.input_location, &cmd.output_location)
+                .await
         }
     }
 }


### PR DESCRIPTION
## What

Added an `unarchive` command to `s3-archiver` to extract files in the ZIP to a location in S3.

## Why

It is useful to be able to reverse the process of archiving.

## Notes
This iteration of this command is intend to be simple with features such as including and excluding files to be added later.

