### PR TITLE
List Archive In S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Unarchive command to extract files into S3.
+- List files in archive reading only Zip Central Directory data.
 
 ## 0.1.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "function_name",
  "futures",
  "pin-project-lite",
+ "predicates",
  "rand",
  "rand_chacha",
  "serde",
@@ -1011,6 +1012,15 @@ checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1540,6 +1550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,13 +1679,16 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "predicates"
-version = "2.1.1"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
 dependencies = [
  "difflib",
+ "float-cmp",
  "itertools",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ cobalt-async = { version = "0.4.0", features = ["checksum"]}
 futures = "0.3.25"
 pin-project-lite = "0.2.9"
 serde = { version = "1.0.150", features = ["derive"] }
-serde_json =  "1.0.89"
+serde_json = "1.0.89"
 tokio = { version = "1.23.0", features = ["macros", "rt", "rt-multi-thread", "io-util"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
 url = { version = "2.3.1", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ cobalt-async = { version = "0.4.0", features = ["checksum"]}
 futures = "0.3.25"
 pin-project-lite = "0.2.9"
 serde = { version = "1.0.150", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json =  "1.0.89"
 tokio = { version = "1.23.0", features = ["macros", "rt", "rt-multi-thread", "io-util"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
 url = { version = "2.3.1", features = ["serde"] }
@@ -60,6 +60,7 @@ path = "src/lib.rs"
 [dev-dependencies]
 assert_cmd = "2.0.7"
 function_name = "0.3.0"
+predicates = "2.1.4"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 testcontainers = "0.14.0"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Commands:
   validate-archive   Validate a ZIP archive matches the given manifest
   validate-manifest  Validate the calculated crc32 of files in the manifest match those recorded the manifest
   unarchive          Extract compressed files from archive
+  list               List archive files
   help               Print this message or the help of the given subcommand(s)
 
 Options:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 //! Allows ZIP archives to be created in S3 from files stored in S3.
 pub mod aws;
+mod list;
+pub use list::ZipEntries;
 
 use std::sync::Arc;
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -22,7 +22,7 @@ impl<'a> ZipEntries<'a> {
     }
 }
 
-impl <'a> IntoIterator for &'a ZipEntries<'a> {
+impl<'a> IntoIterator for &'a ZipEntries<'a> {
     type Item = &'a ZipEntry;
     type IntoIter = std::vec::IntoIter<Self::Item>;
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+
+use async_zip::{read::seek::ZipFileReader, ZipEntry};
+use cobalt_aws::s3::S3Object;
+
+use crate::aws::S3ObjectSeekableRead;
+
+/// Provide a method of iterating over the details in of archived
+/// files without
+pub struct ZipEntries<'a>(ZipFileReader<S3ObjectSeekableRead<'a>>);
+
+impl<'a> ZipEntries<'a> {
+    pub async fn new<'b>(
+        client: &'b aws_sdk_s3::Client,
+        src: &'b S3Object,
+        bytes_before_fetch: Option<u64>,
+    ) -> Result<ZipEntries<'b>> {
+        let s3_seek = S3ObjectSeekableRead::new(client, src, bytes_before_fetch).await?;
+        let zip_reader = async_zip::read::seek::ZipFileReader::new(s3_seek).await?;
+        Ok(ZipEntries(zip_reader))
+    }
+
+    pub fn entries(&'a self) -> impl IntoIterator<Item = &'a ZipEntry> {
+        self.0.entries().into_iter()
+    }
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -20,9 +20,13 @@ impl<'a> ZipEntries<'a> {
         let zip_reader = async_zip::read::seek::ZipFileReader::new(s3_seek).await?;
         Ok(ZipEntries(zip_reader))
     }
+}
 
-    /// Return an `IntoIterator` over the entries in the archive file.
-    pub fn entries(&'a self) -> impl IntoIterator<Item = &'a ZipEntry> {
+impl <'a> IntoIterator for &'a ZipEntries<'a> {
+    type Item = &'a ZipEntry;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
         self.0.entries().into_iter()
     }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -14,9 +14,8 @@ impl<'a> ZipEntries<'a> {
     pub async fn new<'b>(
         client: &'b aws_sdk_s3::Client,
         src: &'b S3Object,
-        bytes_before_fetch: Option<u64>,
     ) -> Result<ZipEntries<'b>> {
-        let s3_seek = S3ObjectSeekableRead::new(client, src, bytes_before_fetch).await?;
+        let s3_seek = S3ObjectSeekableRead::new(client, src, None).await?;
         let zip_reader = async_zip::read::seek::ZipFileReader::new(s3_seek).await?;
         Ok(ZipEntries(zip_reader))
     }

--- a/src/list.rs
+++ b/src/list.rs
@@ -6,10 +6,12 @@ use cobalt_aws::s3::S3Object;
 use crate::aws::S3ObjectSeekableRead;
 
 /// Provide a method of iterating over the details in of archived
-/// files without
+/// files without reading the entire archive.
 pub struct ZipEntries<'a>(ZipFileReader<S3ObjectSeekableRead<'a>>);
 
 impl<'a> ZipEntries<'a> {
+
+    ///Create a new `ZipEntries` for the `src` object.
     pub async fn new<'b>(
         client: &'b aws_sdk_s3::Client,
         src: &'b S3Object,
@@ -20,6 +22,7 @@ impl<'a> ZipEntries<'a> {
         Ok(ZipEntries(zip_reader))
     }
 
+    /// Return an `IntoIterator` over the entries in the archive file.
     pub fn entries(&'a self) -> impl IntoIterator<Item = &'a ZipEntry> {
         self.0.entries().into_iter()
     }

--- a/src/list.rs
+++ b/src/list.rs
@@ -10,7 +10,6 @@ use crate::aws::S3ObjectSeekableRead;
 pub struct ZipEntries<'a>(ZipFileReader<S3ObjectSeekableRead<'a>>);
 
 impl<'a> ZipEntries<'a> {
-
     ///Create a new `ZipEntries` for the `src` object.
     pub async fn new<'b>(
         client: &'b aws_sdk_s3::Client,

--- a/src/list.rs
+++ b/src/list.rs
@@ -5,7 +5,7 @@ use cobalt_aws::s3::S3Object;
 
 use crate::aws::S3ObjectSeekableRead;
 
-/// Provide a method of iterating over the details in of archived
+/// Provide a method of iterating over the details of archived
 /// files without reading the entire archive.
 pub struct ZipEntries<'a>(ZipFileReader<S3ObjectSeekableRead<'a>>);
 

--- a/src/main_cli.rs
+++ b/src/main_cli.rs
@@ -293,6 +293,12 @@ impl From<&ZipEntry> for ListZipEntry {
 }
 
 /// Print the files in the archive.
+/// Prints out the:
+/// * Uncompressed size.
+/// * Last modified date.
+/// * Last modified time.
+/// * File name
+/// Quiet flag will only print out the entry data without headers.
 fn print_entries(src: &Url, entries: &ZipEntries, quiet: bool) {
     if !quiet {
         println!("Archive: {:}", src);
@@ -326,6 +332,12 @@ fn print_entries(src: &Url, entries: &ZipEntries, quiet: bool) {
 }
 
 /// Print the files in the archive.
+/// Prints out the same information as `print_entries` and additionally:
+/// * Compression method.
+/// * Compressed size.
+/// * Compression percentage.
+/// * CRC-32
+/// Quiet flag will only print out the entry data without headers.
 fn print_entries_verbose(src: &Url, entries: &ZipEntries, quiet: bool) {
     if !quiet {
         println!("Archive: {:}", src);

--- a/src/main_cli.rs
+++ b/src/main_cli.rs
@@ -6,8 +6,8 @@ use clap::{Parser, Subcommand, ValueEnum};
 use cobalt_aws::config;
 use cobalt_aws::s3::S3Object;
 use cobalt_s3_archiver as s3_archiver;
-use s3_archiver::{Archiver, Compression, ZipEntries};
 use futures::prelude::*;
+use s3_archiver::{Archiver, Compression, ZipEntries};
 use serde::Serialize;
 use std::io::{BufRead, BufReader};
 use tracing_subscriber::EnvFilter;
@@ -179,12 +179,8 @@ async fn main() -> Result<()> {
         }
         Command::ValidateArchive(cmd) => match cmd.crc32_validation_type {
             CRC32ValidationType::Bytes => {
-                s3_archiver::validate_zip_entry_bytes(
-                    &client,
-                    &cmd.manifest_file,
-                    &cmd.zip_file,
-                )
-                .await?;
+                s3_archiver::validate_zip_entry_bytes(&client, &cmd.manifest_file, &cmd.zip_file)
+                    .await?;
                 println!(
                     "The input archive {:?} bytes matched the manifest {:?}",
                     &cmd.zip_file, &cmd.manifest_file
@@ -192,12 +188,8 @@ async fn main() -> Result<()> {
                 Ok(())
             }
             CRC32ValidationType::CentralDirectory => {
-                s3_archiver::validate_zip_central_dir(
-                    &client,
-                    &cmd.manifest_file,
-                    &cmd.zip_file,
-                )
-                .await?;
+                s3_archiver::validate_zip_central_dir(&client, &cmd.manifest_file, &cmd.zip_file)
+                    .await?;
                 println!(
                     "The input archive {:?} central directory matched the manifest {:?}",
                     &cmd.zip_file, &cmd.manifest_file
@@ -238,13 +230,11 @@ async fn main() -> Result<()> {
             .await
         }
         Command::List(cmd) if cmd.json => {
-            let entries =
-                s3_archiver::ZipEntries::new(&client, &cmd.input_location, None).await?;
+            let entries = s3_archiver::ZipEntries::new(&client, &cmd.input_location, None).await?;
             print_entries_json(&entries)
         }
         Command::List(cmd) => {
-            let entries =
-                s3_archiver::ZipEntries::new(&client, &cmd.input_location, None).await?;
+            let entries = s3_archiver::ZipEntries::new(&client, &cmd.input_location, None).await?;
             if cmd.verbose {
                 print_entries_verbose(&Url::try_from(&cmd.input_location)?, &entries, cmd.quiet);
             } else {

--- a/src/main_cli.rs
+++ b/src/main_cli.rs
@@ -230,11 +230,11 @@ async fn main() -> Result<()> {
             .await
         }
         Command::List(cmd) if cmd.json => {
-            let entries = s3_archiver::ZipEntries::new(&client, &cmd.input_location, None).await?;
+            let entries = s3_archiver::ZipEntries::new(&client, &cmd.input_location).await?;
             print_entries_json(&entries)
         }
         Command::List(cmd) => {
-            let entries = s3_archiver::ZipEntries::new(&client, &cmd.input_location, None).await?;
+            let entries = s3_archiver::ZipEntries::new(&client, &cmd.input_location).await?;
             if cmd.verbose {
                 print_entries_verbose(&Url::try_from(&cmd.input_location)?, &entries, cmd.quiet);
             } else {

--- a/src/main_cli.rs
+++ b/src/main_cli.rs
@@ -299,7 +299,7 @@ fn print_entries(src: &Url, entries: &ZipEntries, quiet: bool) {
     }
     let mut total_size: u32 = 0;
     let mut file_count: u32 = 0;
-    for entry in entries.entries() {
+    for entry in entries {
         let entry = ListZipEntry::from(entry);
         println!(
             "{:>9} {:>10} {:>5}  {}",
@@ -342,7 +342,7 @@ fn print_entries_verbose(src: &Url, entries: &ZipEntries, quiet: bool) {
     let mut total_size: u32 = 0;
     let mut total_length: u32 = 0;
     let mut file_count: u32 = 0;
-    for entry in entries.entries() {
+    for entry in entries {
         let entry: ListZipEntry = ListZipEntry::from(entry);
         println!(
             "{:>9} {:>6?} {:>7} {:>3}% {:>10} {:>5} {:08} {}",
@@ -373,7 +373,7 @@ fn print_entries_verbose(src: &Url, entries: &ZipEntries, quiet: bool) {
 }
 
 pub fn print_entries_json(entries: &ZipEntries) -> Result<()> {
-    for entry in entries.entries() {
+    for entry in entries {
         println!("{}", serde_json::to_string(&ListZipEntry::from(entry))?)
     }
     Ok(())

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -641,7 +641,7 @@ async fn test_list_archive() {
     fixtures::create_and_validate_zip(&s3_client, &args)
         .await
         .unwrap();
-    let entries = cobalt_s3_archiver::ZipEntries::new(&s3_client, &args.dst_obj, None)
+    let entries = cobalt_s3_archiver::ZipEntries::new(&s3_client, &args.dst_obj)
         .await
         .unwrap();
     for (obj, entry) in args.src_keys.iter().zip(entries.into_iter()) {

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -644,7 +644,7 @@ async fn test_list_archive() {
     let entries = cobalt_s3_archiver::ZipEntries::new(&s3_client, &args.dst_obj, None)
         .await
         .unwrap();
-    for (obj, entry) in args.src_keys.iter().zip(entries.entries()) {
+    for (obj, entry) in args.src_keys.iter().zip(entries.into_iter()) {
         assert_eq!(obj, entry.filename())
     }
 }

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -629,3 +629,22 @@ async fn test_check_unarchive_with_dirs() {
             .unwrap());
     }
 }
+
+#[tokio::test]
+#[named]
+async fn test_list_archive() {
+    let test_client = S3TestClient::default();
+    let (_container, s3_client) = test_client.client().await;
+
+    let mut rng = fixtures::seeded_rng(function_name!());
+    let args = fixtures::CheckZipArgs::seeded_args(&mut rng, 10, Some(&["dir_one", "dir_two"]));
+    fixtures::create_and_validate_zip(&s3_client, &args)
+        .await
+        .unwrap();
+    let entries = cobalt_s3_archiver::ZipEntries::new(&s3_client, &args.dst_obj, None)
+        .await
+        .unwrap();
+    for (obj, entry) in args.src_keys.iter().zip(entries.entries()) {
+        assert_eq!(obj, entry.filename())
+    }
+}


### PR DESCRIPTION
## What

Added the `list` command to read the list of files in the archive from the ZIP central directory.

By default the entries will include:

* Uncompressed size.
* Last modification date.
* Last modification time.
* File name

The total uncompressed size and file count is included in the table footer.

Using the `-q` option removes the table header and footers, only printing a line for each entry.

The `-v` option add these additional attributes to each row:

* Compression.
* Compressed size.
* Compression percentage.
* crc32

The total compressed size and total compression is added to the table footers.

The `-j` option prints a JSON representation of each ZIP entry on a new line. The `-q` option is not compatible `-v` or `-q`.

## Why

Being able to list the contents of ZIP archives stored in S3 without downloading the entire ZIP archive is useful for management and querying.
